### PR TITLE
Enable base64 session export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ env/
 *.swp
 *.swo
 
+# 패키징된 하위 모듈
+tg_session_manager/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - ✅ **2FA 지원**: 인증코드와 2차 비밀번호 모두 처리 (3회 재시도)
 - ✅ **세션 백업**: 기존 세션 덮어쓰기 시 자동 백업
 - ✅ **Base64 변환**: 세션 파일을 문자열로 변환하여 이동/공유 가능
+- ✅ **Base64 저장**: 변환된 문자열을 파일로 보관하여 손쉽게 공유
 - ✅ **로깅 시스템**: 모든 작업 내역 자동 기록
 - ✅ **보안 고려**: .gitignore로 민감 정보 보호
 
@@ -77,6 +78,7 @@ python main.py
 인증 코드 입력 (1/3): 12345
 ✓ 세션 생성 성공!
 Base64: U2Vzc2lvbkZpbGVDb250ZW50cy4uLg==...
+저장 경로: base64_strings/telethon/12345678.txt
 ```
 
 ## 📁 디렉토리 구조
@@ -87,6 +89,11 @@ tg_session_manager/
 │   ├── pyrogram/         # Pyrogram 세션
 │   ├── telegram-bot/     # Bot 세션
 │   └── tdlib/           # TDLib 세션
+├── base64_strings/       # Base64 문자열 저장
+│   ├── telethon/
+│   ├── pyrogram/
+│   ├── telegram-bot/
+│   └── tdlib/
 ├── logs/                 # 로그 파일
 ├── api_configs.json      # API 설정 (자동 생성)
 └── *.py                  # 소스 코드

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ from typing import Dict
 # 기본 경로 설정
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 SESSIONS_DIR = os.path.join(BASE_DIR, "sessions")
+BASE64_DIR = os.path.join(BASE_DIR, "base64_strings")
 API_CONFIG_FILE = os.path.join(BASE_DIR, "api_configs.json")
 
 # 라이브러리별 세션 디렉토리
@@ -17,10 +18,18 @@ SESSION_DIRS: Dict[str, str] = {
     "tdlib": os.path.join(SESSIONS_DIR, "tdlib")
 }
 
+# 라이브러리별 Base64 문자열 저장 디렉토리
+BASE64_DIRS: Dict[str, str] = {
+    "telethon": os.path.join(BASE64_DIR, "telethon"),
+    "pyrogram": os.path.join(BASE64_DIR, "pyrogram"),
+    "telegram-bot": os.path.join(BASE64_DIR, "telegram-bot"),
+    "tdlib": os.path.join(BASE64_DIR, "tdlib")
+}
+
 # 기본 설정값
 MAX_RETRY_ATTEMPTS = 3
 DEFAULT_TIMEOUT = 60
 
 # 디렉토리 생성
-for dir_path in SESSION_DIRS.values():
+for dir_path in list(SESSION_DIRS.values()) + list(BASE64_DIRS.values()):
     os.makedirs(dir_path, exist_ok=True)

--- a/logger.py
+++ b/logger.py
@@ -61,7 +61,11 @@ class SessionLogger:
     def log_api_registered(self, api_name: str):
         """API 등록 로그"""
         self.logger.info(f"API 등록: {api_name}")
-    
+
     def log_error(self, error_msg: str):
         """에러 로그"""
         self.logger.error(f"에러: {error_msg}")
+
+    def log_base64_saved(self, library: str, phone: str, path: str):
+        """Base64 문자열 저장 로그"""
+        self.logger.info(f"Base64 저장: {library} - {phone} -> {path}")

--- a/main.py
+++ b/main.py
@@ -7,9 +7,13 @@ import os
 from typing import List, Dict
 from api_manager import APIManager
 from session_factory import SessionFactory
-from config import MAX_RETRY_ATTEMPTS, SESSION_DIRS
+from config import MAX_RETRY_ATTEMPTS, SESSION_DIRS, BASE64_DIRS
 from logger import SessionLogger
-from session_utils import backup_existing_session, extract_session_name
+from session_utils import (
+    backup_existing_session,
+    extract_session_name,
+    save_base64_string,
+)
 
 
 class TelegramSessionManager:
@@ -167,10 +171,17 @@ class TelegramSessionManager:
                     self.print_colored("✅ 세션 생성 성공!", "green")
                     self.logger.log_session_created(library, phone, True)
                     
-                    # Base64 문자열 생성
+                    # Base64 문자열 생성 및 저장
                     base64_str = manager.session_to_string(phone)
                     if base64_str:
                         self.print_colored(f"🔤 Base64: {base64_str[:50]}...", "cyan")
+
+                        session_name = extract_session_name(phone)
+                        output_dir = BASE64_DIRS[library]
+                        output_path = os.path.join(output_dir, f"{session_name}.txt")
+                        if save_base64_string(base64_str, output_path):
+                            self.print_colored(f"💾 저장: {os.path.basename(output_path)}", "green")
+                            self.logger.log_base64_saved(library, phone, output_path)
                     
                     return True
                     

--- a/session_utils.py
+++ b/session_utils.py
@@ -39,6 +39,17 @@ def base64_to_session(base64_string: str, output_path: str) -> bool:
         return False
 
 
+def save_base64_string(base64_string: str, output_path: str) -> bool:
+    """base64 문자열을 파일로 저장"""
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(base64_string)
+        return True
+    except Exception as e:
+        print(f"Base64 저장 실패: {e}")
+        return False
+
+
 def validate_session_file(session_file_path: str) -> bool:
     """세션 파일 유효성 검사"""
     # 파일 존재 여부와 크기 확인


### PR DESCRIPTION
## Summary
- support optional directory for storing base64 strings
- allow saving base64 strings in a text file
- log saved location
- document new feature
- ignore packaging folder

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68637ba47f1083279843e2d49c124f63